### PR TITLE
Init script and remove proxy dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ used in cloudformation, i.e when creating a RDS db with cloudformation.
 ## Installation
 
 ```
-git clone repo
+# git clone the repo
+./init.sh
 ./deploy-all.sh
 ```

--- a/ecs-task/package.json
+++ b/ecs-task/package.json
@@ -6,8 +6,7 @@
   "dependencies": {
     "async": "^1.4.2",
     "aws-sdk": "^2.2.10",
-    "minimist": "^1.2.0",
-    "sony-aws-proxy-config": "^1.0.3"
+    "minimist": "^1.2.0"
   },
   "devDependencies": {},
   "scripts": {

--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+for pkg in */package.json; do
+  name=`dirname $pkg`
+  echo "Initializing $name..."
+  (cd $name && npm install)
+  echo "Done!"
+done


### PR DESCRIPTION
Added instruction to run `./init.sh` before deploying to get `npm install` run in all relevant subdirectories.
